### PR TITLE
RBS-OC-001, Add ability to create carbon chains of arbitrary length; rearrange based on electronegativity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+
+jdk:
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 # organic-chemistry
+[![Build Status](https://travis-ci.org/robertbrako/organic-chemistry.svg?branch=master)](https://travis-ci.org/robertbrako/organic-chemistry)
+<br>
+Converting my organic chemistry textbook into a java program has been a lot of fun!
 
-Converting my organic chemisry textbook into a java program has been a lot of fun!
+Sample input:
+
+        Element carbon1 = prepareCompound(CARBON, 3);
+        Element carbon2 = prepareCompound(CARBON, 2);
+        Element carbon3 = prepareCompound(CARBON, 2);
+        Element carbon4 = prepareCompound(CARBON, 2);
+        Element nitro = prepareCompound(NITROGEN, 2);
+
+        Element.bond(carbon3, carbon1);
+        Element.bond(carbon4, carbon3);
+        Element.bond(carbon4, carbon2);
+        Element.bond(nitro, carbon2);
+
+        assertFalse(carbon1.canBond());
+        assertFalse(carbon2.canBond());
+        assertFalse(carbon3.canBond());
+        assertFalse(carbon4.canBond());
+        assertFalse(nitro.canBond());
+
+        char[][] graph = Element.graph(carbon3);
+        for (char[] line : graph) {
+            System.out.println(line);
+        }
+
+Sample Output:
+
+        H N H
+        H C H
+        H C H
+        H C H
+        H C H
+          H
+
+Perhaps someday I'll see if it can handle Adenine, Thymine, Cytosine, and Guanine...

--- a/src/main/java/com/rmbcorp/organicchemistry/elements/BondGroup.java
+++ b/src/main/java/com/rmbcorp/organicchemistry/elements/BondGroup.java
@@ -1,0 +1,95 @@
+/*
+* Copyright 2017 by Robert M. Brako,
+* All rights reserved.
+*
+* Permission is not granted to any person or entity to obtain a copy of this software and associated files
+* (the "Software"), to deal in the Software, which includes without limitation any rights to use, copy, modify, merge,
+* publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so.  Permission may only be obtained by a signed and dated license agreement between licensor Robert
+* Brako and prospective licensee.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+* WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.rmbcorp.organicchemistry.elements;
+
+class BondGroup {
+    int[] cardinals = { 0, 0, 0, 0 };//N E S W
+    Element[] bonds;
+    int bondCount = 0;
+
+    BondGroup(int size) {
+        bonds = new Element[size];
+    }
+
+    int add(Element element) {
+        int returnIndex = -1;
+        int complement = -1;
+        for (int i = 0; i < cardinals.length; i++) {
+            if (cardinals[i] < 1) {
+                cardinals[i] = 1;
+                bonds[i] = element;
+                complement = (i + 2) % 4;
+                bondCount++;
+                returnIndex = i;
+                break;
+            }
+        }
+        rearrangeBond(element, complement);
+        return returnIndex;
+    }
+
+    private void rearrangeBond(Element element, int complement) {
+        Element opposite = bonds[complement];
+        if (opposite != null && element.electroNegativity() > opposite.electroNegativity()) {
+            for (int i = 0; i < cardinals.length; i++) {
+                if (cardinals[i] < 1) {
+                    cardinals[i] = 1;
+                    bonds[i] = opposite;
+                    bonds[(complement)] = null;
+                    cardinals[(complement)] = 0;
+                }
+            }
+        }
+    }
+
+    int add(Element element, int oldIndex) {
+        Element toPop;
+        int complement = (oldIndex + 2) % 4;
+        if (bonds[complement] != null) {
+            toPop = bonds[complement];
+            bonds[complement] = element;
+            complement = 0;
+            while(bonds[complement] != null) {
+                complement++;
+            }
+            bonds[complement] = toPop;
+        } else {
+            bonds[complement] = element;
+        }
+        cardinals[complement] = 1;
+        bondCount++;
+        rearrangeBond(element, oldIndex);
+        return oldIndex;
+    }
+
+    int bondCount() {
+        return bondCount;
+    }
+
+    int bondCountWith(Element element) {
+        int counter = 0;
+        for (Element existing : bonds) {
+            if (element.equals(existing)) {
+                counter++;
+            }
+        }
+        return  counter;
+    }
+
+    Element get(int index) {
+        return bonds[index];
+    }
+}

--- a/src/test/java/com/rmbcorp/organicchemistry/elements/ElementTest.java
+++ b/src/test/java/com/rmbcorp/organicchemistry/elements/ElementTest.java
@@ -1,0 +1,69 @@
+/*
+* Copyright 2017 by Robert M. Brako,
+* All rights reserved.
+*
+* Permission is not granted to any person or entity to obtain a copy of this software and associated files
+* (the "Software"), to deal in the Software, which includes without limitation any rights to use, copy, modify, merge,
+* publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+* furnished to do so.  Permission may only be obtained by a signed and dated license agreement between licensor Robert
+* Brako and prospective licensee.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+* WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+* OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+package com.rmbcorp.organicchemistry.elements;
+
+import org.junit.Test;
+
+import static com.rmbcorp.organicchemistry.elements.ElementType.CARBON;
+import static com.rmbcorp.organicchemistry.elements.ElementType.HYDROGEN;
+import static com.rmbcorp.organicchemistry.elements.ElementType.NITROGEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ElementTest {
+
+    @Test
+    public void weCanCreateMethaneTest() {
+        Element carbon = new Element(CARBON);
+        for (int i = 0; i  < 4; i++) {
+            Element.bond(carbon, new Element(HYDROGEN));
+        }
+        assertEquals(4, carbon.totalBondCount());
+        assertFalse(carbon.canBond());
+    }
+
+    @Test
+    public void graphTest() {
+        Element carbon1 = prepareCompound(CARBON, 3);
+        Element carbon2 = prepareCompound(CARBON, 2);
+        Element carbon3 = prepareCompound(CARBON, 2);
+        Element carbon4 = prepareCompound(CARBON, 2);
+        Element nitro = prepareCompound(NITROGEN, 2);
+
+        Element.bond(carbon3, carbon1);
+        Element.bond(carbon4, carbon3);
+        Element.bond(carbon4, carbon2);
+        Element.bond(nitro, carbon2);
+
+        assertFalse(carbon1.canBond());
+        assertFalse(carbon2.canBond());
+        assertFalse(carbon3.canBond());
+        assertFalse(carbon4.canBond());
+        assertFalse(nitro.canBond());
+        char[][] graph = Element.graph(carbon3);
+        for (char[] line : graph) {
+            System.out.println(line);
+        }
+    }
+
+    private Element prepareCompound(ElementType type, int hCount) {
+        Element element = new Element(type);
+        for (int i = 0; i  < hCount; i++) {
+            Element.bond(element, new Element(HYDROGEN));
+        }
+        return element;
+    }
+}

--- a/src/test/java/com/rmbcorp/organicchemistry/elements/OrbitalNodeTest.java
+++ b/src/test/java/com/rmbcorp/organicchemistry/elements/OrbitalNodeTest.java
@@ -73,33 +73,4 @@ public class OrbitalNodeTest {
         assertTrue(HYDROGEN.getOrbitalReference().canBond());
         assertTrue(carbonLastNode.equals(CARBON.getOrbitalReference().getLastNodeEnergyType()));
     }
-
-    @Test
-    public void weCanCreateMethaneTest() {
-        Element carbon = new Element(CARBON);
-        for (int i = 0; i  < 4; i++) {
-            Element.bond(carbon, new Element(HYDROGEN));
-        }
-        assertEquals(4, carbon.totalBondCount());
-        assertFalse(carbon.canBond());
-    }
-
-    @Test
-    public void graphTest() {
-        Element carbon1 = prepareMethyl(3);
-        Element carbon2 = prepareMethyl(3);
-        Element.bond(carbon1, carbon2);
-        char[][] graph = Element.graph(carbon2);
-        for (char[] line : graph) {
-            System.out.println(line);
-        }
-    }
-
-    private Element prepareMethyl(int hCount) {
-        Element carbon = new Element(CARBON);
-        for (int i = 0; i  < hCount; i++) {
-            Element.bond(carbon, new Element(HYDROGEN));
-        }
-        return carbon;
-    }
 }


### PR DESCRIPTION
Electronegativity calcs is simply based on atomic number (electron number) for now.  Will need to account for double- and triple-bonding before making a real implementation.  Also added travis-ci integration.